### PR TITLE
Coleman/frontend results page tailwind

### DIFF
--- a/client/src/EncounterGeneratorPage/result.tsx
+++ b/client/src/EncounterGeneratorPage/result.tsx
@@ -3,11 +3,11 @@ import { Link } from "react-router-dom";
 
 const Result = ({ result }) => {
   return (
-    <div className=" h-screen mx-auto my-0 flex flex-col items-center max-w-fit p-5">
-      <h1 className="font-header decoration-1 text-4xl text-white h-1/6">
+    <div className="h-screen mx-auto my-0 flex flex-col items-center max-w-fit px-5">
+      <h1 className="font-header decoration-1 text-4xl text-white h-24">
         Your Encounter
       </h1>
-      <p className="wqe max-w-md text-l mb-5 tracking-wide leading-7 bg-[url('./assets/result-image.jpg')] bg-no-repeat bg-origin-border bg-center">
+      <p className="max-w-md max-h-screen text-l mb-5 tracking-wide leading-7 bg-[url('./assets/result-image.jpg')] bg-no-repeat bg-origin-border bg-center">
         {result}
       </p>
       <button className="bg-br-red w-5/6 h-10 rounded p-1 my-3">


### PR DESCRIPTION
Added to tailwind for results page. There is a py-20 on the div that holds the entire page when you use the inspect tool. I could not find where that was but that will help take some of the padding-top away and make it fit better for mobile view.